### PR TITLE
ci(gradle): build workflow から不要な 'Restore gradle.properties' step を削除

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,13 +30,5 @@ jobs:
         distribution: 'temurin'
     - name: Make gradlew executable
       run: chmod +x ./gradlew
-    - name: Restore gradle.properties
-      env:
-        GRADLE_PROPERTIES: ${{ secrets.GRADLE_PROPERTIES }}
-      shell: bash
-      run: |
-        mkdir -p ~/.gradle/
-        echo "GRADLE_USER_HOME=${HOME}/.gradle" >> $GITHUB_ENV
-        echo "${GRADLE_PROPERTIES}" > ~/.gradle/gradle.properties
     - name: Run build with Gradle Wrapper
       run: ./gradlew build


### PR DESCRIPTION
## 概要

CI の build/test 用 workflow (`.github/workflows/gradle.yml`) から、不要な `Restore gradle.properties` step を削除しました。

この step は `secrets.GRADLE_PROPERTIES` を `~/.gradle/gradle.properties` に書き戻すものでしたが、書き戻される内容は Maven Central 認証情報 (`mavenCentralUsername`, `mavenCentralPassword`) と PGP 署名情報 (`signing.keyId`, `signing.password`, `signing.secretKeyRingFile`) であり、`./gradlew build` では一切参照されません。

`build.gradle` の `mavenPublishing` ブロックは `publishToMavenCentral` タスクでのみ有効になるため、通常の build/test においては不要です。

## 変更内容

- `.github/workflows/gradle.yml`: `Restore gradle.properties` step を削除

## publish workflow を変更しない理由

`gradle-publish.yml` (release イベント駆動) は独自の GPG 取り込み (`crazy-max/ghaction-import-gpg`) と `ORG_GRADLE_PROJECT_*` 環境変数による認証・署名機構を持っており、今回の変更の影響を受けません。

## 確認

- `git diff --check` → 空白エラーなし
- `./gradlew build` → BUILD SUCCESSFUL
- `./gradlew test` → BUILD SUCCESSFUL

## 変更ファイル

- `.github/workflows/gradle.yml` のみ
