### PR TITLE
test: 既存Splateクエリの条件バリエーションを追加

### DIFF
--- a/src/test/java/test/EmployeeRepositoryTest.java
+++ b/src/test/java/test/EmployeeRepositoryTest.java
@@ -74,6 +74,9 @@ class EmployeeRepositoryTest {
 		assertEquals(ret.get().getId(), 4L);
 		assertEquals(ret.get().getName(), "Test");
 		assertEquals(ret.get().getSalary(), 3000);
+
+		// Splate経路でも確認
+		assertEquals(target.sampleCount(null, null), 4);
 	}
 
 	@Test
@@ -82,5 +85,39 @@ class EmployeeRepositoryTest {
 		assertEquals(target.sampleCount(1700, 2000), 3);
 	}
 
-	// TODO テストケース充実
+	@Test
+	void testQueryForListAll() {
+		// 条件なしで全件
+		assertEquals(target.queryForList(null, null).size(), 3);
+	}
+
+	@Test
+	void testQueryForListNoMatch() {
+		// 該当なしで空List
+		assertEquals(target.queryForList(3000, 4000).size(), 0);
+	}
+
+	@Test
+	void testCountAll() {
+		// 条件なし
+		assertEquals(target.sampleCount(null, null), 3);
+	}
+
+	@Test
+	void testCountLeftOnly() {
+		// 上限のみ
+		assertEquals(target.sampleCount(null, 1999), 2);
+	}
+
+	@Test
+	void testCountRightOnly() {
+		// 下限のみ
+		assertEquals(target.sampleCount(2000, null), 1);
+	}
+
+	@Test
+	void testCountNoMatch() {
+		// 該当なし
+		assertEquals(target.sampleCount(3000, 4000), 0);
+	}
 }


### PR DESCRIPTION
## 概要

既存の `@Splate` 実装の回帰防止のため、条件バリエーションのテストケースを追加しました。

## 変更内容

`src/test/java/test/EmployeeRepositoryTest.java` のみを変更しています。

### 追加したテストケース

| テストメソッド | 確認内容 |
|---|---|
| `testQueryForListAll` | `salaryMin = null, salaryMax = null` で全3件取得 |
| `testQueryForListNoMatch` | 該当なし範囲で空Listが返る |
| `testCountAll` | `salaryMin = null, salaryMax = null` で3件 |
| `testCountLeftOnly` | `salaryMin = null, salaryMax = 1999` で2件 |
| `testCountRightOnly` | `salaryMin = 2000, salaryMax = null` で1件 |
| `testCountNoMatch` | 該当なし条件で0件 |

### 既存テストの拡張

- `testInsert()`: INSERT後に `sampleCount(null, null)` でSplate経路の一貫性を確認

### 削除

- `// TODO テストケース充実` コメント

## 実施しなかったこと

- `queryForList` の順序依存assert（SQLに ORDER BY がないため）
- JavaBean引数サポートの実装
- `Optional.empty()` 対応の実装
- `src/main/java` やSQLファイル、`build.gradle` の変更
- AssertJなど新規テストライブラリの追加

## 確認コマンド

- `git diff --check` ✅
- `./gradlew test` ✅ BUILD SUCCESSFUL
- `./gradlew build` ✅ BUILD SUCCESSFUL
