### PR TITLE
docs: CHANGELOGとリリース手順を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+## 0.1.2 - TBD
+
+- READMEの依存関係例修正
+- 動作確認済み環境と互換性注意の追記
+- build workflowから不要な `Restore gradle.properties` step を削除
+- 既存Splateクエリの条件バリエーションテスト追加
+- 機能追加はないこと
+- JavaBean引数サポートは未対応のままであること
+- Spring Boot 4.x対応は未検証であること
+
+## 0.1.1
+
+- Maven Central公開設定の整備（publish workflow、Gradleプラグイン設定、GPG署名）
+- Maven Centralへの初回公開
+- Gradle設定の整理
+- Spring Boot 3.4.7対応

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,4 @@
 
 ## 0.1.1
 
-- Maven Central公開設定の整備（publish workflow、Gradleプラグイン設定、GPG署名）
-- Maven Centralへの初回公開
-- Gradle設定の整理
-- Spring Boot 3.4.7対応
+- Maven Central公開済みの現行バージョン

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,44 @@
+# Release Procedure
+
+## リリース前確認
+
+```bash
+./gradlew clean test
+./gradlew build
+git diff --check
+```
+
+## リリース手順
+
+1. `build.gradle` の `mavenPublishing.coordinates` のバージョンを更新する
+   - 例: `'0.1.1'` → `'0.1.2'`
+
+2. READMEの依存関係例も同じバージョンへ更新する
+   - `implementation 'io.github.whitenoise0000:spring-data-jdbc-splate:0.1.2'`
+
+3. `CHANGELOG.md` の対象バージョンの日付を `TBD` から確定日付に変更する
+
+4. 上記をコミットし、mainブランチへマージする
+
+5. GitHub上で main ブランチから GitHub Release を作成する
+   - タグには `v` プレフィックス付きのバージョンを指定（例: `v0.1.2`）
+   - Release title にはバージョン番号を記載（例: `v0.1.2`）
+   - CHANGELOG の内容を参考にリリースノートを記入する
+
+6. Release 作成イベントにより `.github/workflows/gradle-publish.yml` が発火し、Maven Central へ自動公開される
+
+## シークレット情報
+
+`.github/workflows/gradle-publish.yml` では以下のシークレットを使用しています（値は GitHub Secrets 経由で渡すこと）：
+
+- `MAVEN_USERNAME`
+- `MAVEN_PASSWORD`
+- `GPG_PRIVATE_KEY`
+- `GPG_PASSPHRASE`
+- `SIGNING_KEY_ID`
+
+## 公開後確認
+
+- Maven Central の [Central Portal](https://central.sonatype.com/) で反映を確認する
+- 反映までに数時間〜1日程度かかる場合がある
+- 公開後、該当バージョンの `./gradlew test` が正常に動作することを改めて確認する


### PR DESCRIPTION
本PRは v0.1.2 の実リリースではなく、CHANGELOGとリリース手順を先に整備するためのdocs-only PRです。
バージョン更新、READMEの依存例更新、GitHub Release作成は後続PRで実施します。