### PR TITLE
docs: README冒頭にライブラリの利用意図を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Spring Data JDBCを拡張し、2Way-SQL実行用の追加アノテーションを提供します。
 
+Spring Data JDBC の Repository を使いつつ、長いSQLや条件分岐SQLを `@Query` のJava文字列や `jdbc-named-queries.properties` ではなく、外部 `.sql` ファイルの2Way-SQLとして管理するための小さな拡張ライブラリです。MyBatis / Doma ほど大きな仕組みを導入せず、Spring Data JDBC の延長としてSQLファイルを扱いたいケースを想定しています。
+
 2Way-SQLの解析は、S2JDBC由来の[splate（エス・プレート）](https://mygreen.github.io/splate/)を用いています。
 
 > splate（エス・プレート）は、 2Way-SQL 機能のみを S2JDBC から分離し、使いやすくしたライブラリです。


### PR DESCRIPTION
## 変更内容

README冒頭に、このライブラリが「何のためのものか」を明確にする説明を追記しました。

### 追記した趣旨
- Spring Data JDBC の Repository を使いつつ、長いSQLや条件分岐SQLを外部 `.sql` ファイルとして管理できる
- `@Query` のJava文字列直書きや `jdbc-named-queries.properties` では扱いにくいSQLを、splateの2Way-SQLとして記述できる
- MyBatis / Doma のような大きな仕組みを導入せず、Spring Data JDBC の延長として使う小さな拡張ライブラリである

### 変更ファイル
- `README.md` のみ（+2行）

### 確認結果
- `git diff --check`: 問題なし
- `./gradlew test`: BUILD SUCCESSFUL
- `./gradlew build`: BUILD SUCCESSFUL

### 実施していないこと
- バージョン番号変更 / 依存関係更新
- `src/main/java` / `src/test` 配下の変更
- CHANGELOG / docs/release.md / build.gradle / workflow の変更
- READMEの使い方セクション・注意制約・参考URLの編集
- 機能追加・動作変更
