### PR TITLE
docs: CHANGELOGをUnreleased中心に整理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,20 @@
 
 ## Unreleased
 
-## 0.1.2 - TBD
+### Changed
 
 - READMEの依存関係例修正
 - 動作確認済み環境と互換性注意の追記
 - build workflowから不要な `Restore gradle.properties` step を削除
 - 既存Splateクエリの条件バリエーションテスト追加
-- 機能追加はないこと
-- JavaBean引数サポートは未対応のままであること
-- Spring Boot 4.x対応は未検証であること
+- README冒頭にライブラリの利用意図を追記
+
+### Notes
+
+- 機能追加はありません
+- JavaBean引数サポートは未対応のままです
+- Spring Boot 4.x対応は未検証です
+- 次のMaven Central公開は、機能追加を含む `v0.2.0` を想定しています
 
 ## 0.1.1
 


### PR DESCRIPTION
## 概要

CHANGELOG.md の `0.1.2 - TBD` セクションを削除し、内容を `Unreleased` 配下へ移動・整理しました。

## 変更内容

- `0.1.2 - TBD` セクションを削除し、`Unreleased` 配下に再構成
- `### Changed`（5項目）と `### Notes`（4項目）に区分
- README冒頭追記を `### Changed` に追加
- 次の公開は機能追加を含む `v0.2.0` を想定する旨を `### Notes` に記載
- `## 0.1.1` セクションは維持

## やったこと／やっていないこと

| 実施 | 内容 |
|---|---|
| ✅ | CHANGELOG.md のみ編集 |
| ✅ | v0.1.2 リリース前提を除去 |
| ❌ | バージョン番号の更新（build.gradle, README等） |
| ❌ | docs/release.md の変更 |
| ❌ | GitHub Actions workflow の変更 |
| ❌ | src/main / src/test の変更 |
| ❌ | JavaBean引数サポート、Optional対応、Spring Boot 4対応の実装 |

## 確認コマンド

- `git diff --check` ✅
- `./gradlew test` ✅ BUILD SUCCESSFUL
- `./gradlew build` ✅ BUILD SUCCESSFUL
