### PR TITLE
feat: @Splateメソッドの単一JavaBean引数をサポート

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- `@Splate` メソッドで単一JavaBean引数をサポート
+  - JavaBeans getterプロパティがそのまま2Way-SQL内のバインドパラメータ名として参照可能
+  - 既存SQL（`sampleQuery.sql` / `sampleCount.sql` / `sampleInsert.sql` 等）をそのまま流用できる
+  - `null` の単一JavaBean引数は `IllegalArgumentException` を投げる
+  - 対象外: 複数Bean引数 / `Map` / `Collection` / `Iterable` / `Optional` / 配列引数の展開 / ネストしたBeanプロパティ
+
 ### Changed
 
 - READMEの依存関係例修正
@@ -9,11 +17,10 @@
 - build workflowから不要な `Restore gradle.properties` step を削除
 - 既存Splateクエリの条件バリエーションテスト追加
 - README冒頭にライブラリの利用意図を追記
+- READMEにJavaBean引数の使い方と対応範囲を追記
 
 ### Notes
 
-- 機能追加はありません
-- JavaBean引数サポートは未対応のままです
 - Spring Boot 4.x対応は未検証です
 - 次のMaven Central公開は、機能追加を含む `v0.2.0` を想定しています
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ public interface EmployeeRepository extends CrudRepository<Employee, Long> {
 
 ## 動作確認済み環境
 
-本リポジトリのビルド・テストは、以下の構成で確認しています（`./gradlew test` 19件成功）。
+本リポジトリのビルド・テストは、以下の構成で確認しています（`./gradlew test` テスト成功）。
 
 | 項目 | バージョン |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -59,9 +59,47 @@ public interface EmployeeRepository extends CrudRepository<Employee, Long> {
 }
 ```
 
+### 単一JavaBean引数
+
+`@Splate` メソッドの引数が **単一のJavaBean** である場合、Beanの読み取り可能なJavaBeansプロパティが
+2Way-SQL内の同名バインドパラメータとして展開されます。
+splate 0.3 の `BeanPropertySqlTemplateContext` 相当の挙動です。
+
+```java
+public class EmployeeSearchCondition {
+  private Integer salaryMin;
+  private Integer salaryMax;
+  // getter / setter
+}
+
+public interface EmployeeRepository extends CrudRepository<Employee, Long> {
+
+  @Splate("/sql/sampleQuery.sql")
+  List<Employee> queryForListByCondition(EmployeeSearchCondition condition);
+}
+```
+
+例えば上記メソッド呼び出しでは、`condition.salaryMin` / `condition.salaryMax` が
+`salaryMin` / `salaryMax` としてSQLテンプレートから参照できます。
+
+#### 対応範囲
+
+- 単一JavaBean引数をサポート
+- 既存どおり、複数引数は **引数名** でSQLから参照
+- 単一のスカラー値引数（`Integer` / `String` など）は従来通り **引数名** で参照
+- JavaBeanのgetterプロパティがそのままバインドパラメータ名になる
+- 既存の `.sql` ファイルは変更不要（既存の2Way-SQLをそのまま流用可）
+
+#### 対象外
+
+- `null` の単一JavaBean引数（非対応。`IllegalArgumentException` を投げます）
+- 複数Bean引数
+- `Map` / `Collection` / `Iterable` / `Optional` / 配列 の引数展開
+- ネストしたBeanプロパティ（例：`condition.range.salaryMin` のような参照）
+
 ## 動作確認済み環境
 
-本リポジトリのビルド・テストは、以下の構成で確認しています（`./gradlew test` 9件成功）。
+本リポジトリのビルド・テストは、以下の構成で確認しています（`./gradlew test` 19件成功）。
 
 | 項目 | バージョン |
 | --- | --- |
@@ -89,10 +127,11 @@ public interface EmployeeRepository extends CrudRepository<Employee, Long> {
 
 - 最低限のテストケースのみであり、バリエーション検討不足による<span style="color: red; ">不具合がまだ潜在している</span>と思われます。
 
-- splateの[基本的な使い方](https://mygreen.github.io/splate/howtouse.html)のうち、JavaBeanによるパラメータ指定は未サポートです。
-
 - 1レコード取得の戻り値型に`Optional<T>`ではなく`T`を指定する場合、クラス可視性はpublicとしてください。  
 →`T`のみ指定かつ可視性がpublicではない場合、`IllegalAccessError`が発生します。これはSpring Data JDBC本体も同様です。参考：[Issue #2](https://github.com/WhiteNoise0000/spring-data-jdbc-splate/issues/2)
+
+- 単一JavaBean引数（[対応範囲](#対応範囲)参照）の対象は単純なJavaBeansのみであり、
+Spring Boot 4.x への追従など、本文中に明記した以外の互換性は未検証です。
 
 - OSSライブラリ公開の経験等無く、様々なお作法に疎いので参考にとどめてください。
 

--- a/src/main/java/io/github/whitenoise0000/springdatajdbcsplate/SqlateQuery.java
+++ b/src/main/java/io/github/whitenoise0000/springdatajdbcsplate/SqlateQuery.java
@@ -1,5 +1,12 @@
 package io.github.whitenoise0000.springdatajdbcsplate;
 
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.util.Lazy;
@@ -7,6 +14,7 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.RowMapper;
 
+import com.github.mygreen.splate.BeanPropertySqlTemplateContext;
 import com.github.mygreen.splate.EmptyValueSqlTemplateContext;
 import com.github.mygreen.splate.MapSqlTemplateContext;
 import com.github.mygreen.splate.ProcessResult;
@@ -16,7 +24,7 @@ import com.github.mygreen.splate.SqlTemplateEngine;
 
 /**
  * Splate(2-waySQL)クエリ実行.
- * 
+ *
  * @author WhiteNoise0000
  */
 class SqlateQuery implements RepositoryQuery {
@@ -90,12 +98,83 @@ class SqlateQuery implements RepositoryQuery {
 			return new EmptyValueSqlTemplateContext();
 		}
 
-		// TODO Bean引数
-		// 引数あり
+		// 単一引数
+		Iterator<? extends Parameter> it = queryMethod.getParameters().iterator();
+		if (it.hasNext()) {
+			Parameter param = it.next();
+			if (!it.hasNext()) {
+				Class<?> type = param.getType();
+				// JavaBeanとして展開する型のみ、BeanPropertySqlTemplateContext を利用する
+				if (isJavaBeanArgument(type)) {
+					Object value = params[param.getIndex()];
+					if (value == null) {
+						throw new IllegalArgumentException(
+								"@Splate method '" + queryMethod.getName()
+										+ "' does not accept a null JavaBean argument."
+										+ " Provide a non-null JavaBean instance.");
+					}
+					return new BeanPropertySqlTemplateContext(value);
+				}
+			}
+		}
+
+		// 引数あり(複数 / 単一スカラー)
 		MapSqlTemplateContext context = new MapSqlTemplateContext();
 		queryMethod.getParameters().forEach(param -> {
 			context.addVariable(param.getName().get(), params[param.getIndex()]);
 		});
 		return context;
+	}
+
+	/**
+	 * 単一引数をJavaBeanとして展開する対象かどうかを判定する.
+	 *
+	 * <p>{@code false} を返す型は、Bean展開対象外として従来通り引数名で
+	 * {@link MapSqlTemplateContext} に登録される.</p>
+	 */
+	private static boolean isJavaBeanArgument(Class<?> type) {
+		if (type == null) {
+			return false;
+		}
+		if (type.isPrimitive()) {
+			return false;
+		}
+		if (type.isArray()) {
+			return false;
+		}
+		if (Map.class.isAssignableFrom(type)) {
+			return false;
+		}
+		if (Iterable.class.isAssignableFrom(type)) {
+			return false;
+		}
+		if (Optional.class.isAssignableFrom(type)) {
+			return false;
+		}
+		if (Number.class.isAssignableFrom(type)) {
+			return false;
+		}
+		if (Boolean.class.equals(type)) {
+			return false;
+		}
+		if (Character.class.equals(type)) {
+			return false;
+		}
+		if (Enum.class.isAssignableFrom(type)) {
+			return false;
+		}
+		if (String.class.equals(type)) {
+			return false;
+		}
+		if (Date.class.isAssignableFrom(type)) {
+			return false;
+		}
+		if (UUID.class.equals(type)) {
+			return false;
+		}
+		if (type.getPackageName().startsWith("java.time")) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/src/test/java/test/EmployeeCreateCommand.java
+++ b/src/test/java/test/EmployeeCreateCommand.java
@@ -1,0 +1,37 @@
+package test;
+
+public class EmployeeCreateCommand {
+
+	private Long id;
+
+	private String name;
+
+	private Integer salary;
+
+	public EmployeeCreateCommand() {
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Integer getSalary() {
+		return salary;
+	}
+
+	public void setSalary(Integer salary) {
+		this.salary = salary;
+	}
+}

--- a/src/test/java/test/EmployeeRepository.java
+++ b/src/test/java/test/EmployeeRepository.java
@@ -27,7 +27,17 @@ public interface EmployeeRepository extends CrudRepository<Employee, Long> {
 
 	@Splate("/sql/sampleCount.sql")
 	long sampleCount(Integer salaryMin, Integer salaryMax);
-	
+
+	// 単一JavaBean引数
+	@Splate("/sql/sampleQuery.sql")
+	List<Employee> queryForListByCondition(EmployeeSearchCondition condition);
+
+	@Splate("/sql/sampleCount.sql")
+	long sampleCountByCondition(EmployeeSearchCondition condition);
+
+	@Splate("/sql/sampleInsert.sql")
+	int sampleInsertByCommand(EmployeeCreateCommand command);
+
 	// 標準クエリでTを直接返却
 	Employee findByName(String name);
 }

--- a/src/test/java/test/EmployeeRepositoryTest.java
+++ b/src/test/java/test/EmployeeRepositoryTest.java
@@ -120,4 +120,70 @@ class EmployeeRepositoryTest {
 		// 該当なし
 		assertEquals(target.sampleCount(3000, 4000), 0);
 	}
+
+	// ↓↓@Splate 単一JavaBean引数↓↓
+
+	@Test
+	void testQueryForListByCondition() {
+		// salaryMin=1700, salaryMax=2000 で3件
+		assertEquals(target.queryForListByCondition(condition(1700, 2000)).size(), 3);
+		// salaryMin=1701, salaryMax=1999 で1件
+		assertEquals(target.queryForListByCondition(condition(1701, 1999)).size(), 1);
+		// salaryMin=null, salaryMax=null で全3件
+		assertEquals(target.queryForListByCondition(condition(null, null)).size(), 3);
+		// 該当なし条件で空List
+		assertEquals(target.queryForListByCondition(condition(3000, 4000)).size(), 0);
+	}
+
+	@Test
+	void testSampleCountByCondition() {
+		// salaryMin=null, salaryMax=null で3件
+		assertEquals(target.sampleCountByCondition(condition(null, null)), 3);
+		// salaryMin=null, salaryMax=1999 で2件
+		assertEquals(target.sampleCountByCondition(condition(null, 1999)), 2);
+		// salaryMin=2000, salaryMax=null で1件
+		assertEquals(target.sampleCountByCondition(condition(2000, null)), 1);
+		// 該当なし条件で0件
+		assertEquals(target.sampleCountByCondition(condition(3000, 4000)), 0);
+	}
+
+	@Test
+	void testInsertByCommand() {
+		// JavaBean引数によるINSERT
+		EmployeeCreateCommand command = new EmployeeCreateCommand();
+		command.setId(4L);
+		command.setName("Test");
+		command.setSalary(3000);
+
+		int count = target.sampleInsertByCommand(command);
+		assertEquals(count, 1);
+
+		Optional<Employee> ret = target.findById(4L);
+		assertTrue(ret.isPresent());
+		assertEquals(ret.get().getId(), 4L);
+		assertEquals(ret.get().getName(), "Test");
+		assertEquals(ret.get().getSalary(), 3000);
+
+		// Splate経路でも確認
+		assertEquals(target.sampleCount(null, null), 4);
+	}
+
+	@Test
+	void testQueryForListByConditionNull() {
+		// nullの単一JavaBean引数はIllegalArgumentException
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> target.queryForListByCondition(null));
+		String msg = ex.getMessage().toLowerCase();
+		assertTrue(msg.contains("javabean") || msg.contains("bean"),
+				"Exception message should mention JavaBean/bean: " + ex.getMessage());
+		assertTrue(msg.contains("null"),
+				"Exception message should mention null: " + ex.getMessage());
+	}
+
+	private static EmployeeSearchCondition condition(Integer salaryMin, Integer salaryMax) {
+		EmployeeSearchCondition c = new EmployeeSearchCondition();
+		c.setSalaryMin(salaryMin);
+		c.setSalaryMax(salaryMax);
+		return c;
+	}
 }

--- a/src/test/java/test/EmployeeSearchCondition.java
+++ b/src/test/java/test/EmployeeSearchCondition.java
@@ -1,0 +1,27 @@
+package test;
+
+public class EmployeeSearchCondition {
+
+	private Integer salaryMin;
+
+	private Integer salaryMax;
+
+	public EmployeeSearchCondition() {
+	}
+
+	public Integer getSalaryMin() {
+		return salaryMin;
+	}
+
+	public void setSalaryMin(Integer salaryMin) {
+		this.salaryMin = salaryMin;
+	}
+
+	public Integer getSalaryMax() {
+		return salaryMax;
+	}
+
+	public void setSalaryMax(Integer salaryMax) {
+		this.salaryMax = salaryMax;
+	}
+}


### PR DESCRIPTION
## 概要

`@Splate` メソッドで **単一JavaBean引数** を受け取り、Beanのgetterプロパティを
2Way-SQL内の同名バインドパラメータとして参照できるようにしました。

splate 0.3 の `BeanPropertySqlTemplateContext` 相当の挙動を `SqlateQuery#getContext` に組み込む形です。
既存の複数引数 / 単一スカラー引数の動作は変更しません。

## 変更内容

- `SqlateQuery#getContext` で単一引数かつJavaBean展開対象型のみ `BeanPropertySqlTemplateContext` を使うように分岐
- `null` の単一JavaBean引数は `IllegalArgumentException` を投げる（メッセージに "JavaBean" / "null" を含む）
- JavaBean展開対象外の型（primitive / wrapper / String / Number / Boolean / Character / Enum / BigDecimal / BigInteger / java.time / Date / UUID / Map / Iterable / Collection / 配列 / Optional）は従来通り引数名で扱う
- テスト用JavaBean `EmployeeSearchCondition` / `EmployeeCreateCommand` を新規追加
- Repository に `queryForListByCondition` / `sampleCountByCondition` / `sampleInsertByCommand` を追加
- テストケース 4件追加（List / Count / Insert / null例外）
- READMEに単一JavaBean引数の使用例と対応範囲 / 対象外を追記
- CHANGELOG (Unreleased) に `### Added` セクションを追加し、"JavaBean引数サポートは未対応" のNotesを削除

## 対応範囲

- 単一JavaBean引数
- JavaBeans getterプロパティの展開
- 既存SQLファイル（`sampleQuery.sql` / `sampleCount.sql` / `sampleInsert.sql`）をそのまま流用可能
- 既存の複数引数 / 単一スカラー引数の互換維持

## 対象外

- `null` の単一JavaBean引数（`IllegalArgumentException`）
- 複数Bean引数
- `Map` / `Collection` / `Iterable` / `Optional` / 配列 の引数展開
- ネストBeanプロパティ（例：`condition.range.salaryMin`）
- Spring Boot 4.x対応
- `Optional` 0件時の `Optional.empty()` 対応
- DML判定強化
- `SqlTemplateEngine` のDI化
- Maven Central公開 / バージョン更新 (`v0.2.0` への bump なし)

## 確認

- `git diff --check` (warning only, no error)
- `./gradlew clean test` → 19件成功
- `./gradlew build` → 成功
- テスト内訳: 既存15件 + 新規4件 (`testQueryForListByCondition` / `testSampleCountByCondition` / `testInsertByCommand` / `testQueryForListByConditionNull`)
