### PR TITLE
chore: v0.2.0リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.0 - 2026-06-02
+
 ### Added
 
 - `@Splate` メソッドで単一JavaBean引数をサポート
@@ -22,7 +24,6 @@
 ### Notes
 
 - Spring Boot 4.x対応は未検証です
-- 次のMaven Central公開は、機能追加を含む `v0.2.0` を想定しています
 
 ## 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Spring Data JDBC の Repository を使いつつ、長いSQLや条件分岐SQLを
 
 ```gradle
 dependencies {
-  implementation 'io.github.whitenoise0000:spring-data-jdbc-splate:0.1.1'
+  implementation 'io.github.whitenoise0000:spring-data-jdbc-splate:0.2.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ tasks.named('test') {
 }
 
 mavenPublishing {
-  coordinates('io.github.whitenoise0000', 'spring-data-jdbc-splate', '0.1.1')
+  coordinates('io.github.whitenoise0000', 'spring-data-jdbc-splate', '0.2.0')
 
   // POMファイルに記載される情報を設定
   pom {

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,18 +11,18 @@ git diff --check
 ## リリース手順
 
 1. `build.gradle` の `mavenPublishing.coordinates` のバージョンを更新する
-   - 例: `'0.1.1'` → `'0.1.2'`
+   - 例: `'0.1.1'` → `'0.2.0'`
 
 2. READMEの依存関係例も同じバージョンへ更新する
-   - `implementation 'io.github.whitenoise0000:spring-data-jdbc-splate:0.1.2'`
+   - `implementation 'io.github.whitenoise0000:spring-data-jdbc-splate:0.2.0'`
 
 3. `CHANGELOG.md` の対象バージョンの日付を `TBD` から確定日付に変更する
 
 4. 上記をコミットし、mainブランチへマージする
 
 5. GitHub上で main ブランチから GitHub Release を作成する
-   - タグには `v` プレフィックス付きのバージョンを指定（例: `v0.1.2`）
-   - Release title にはバージョン番号を記載（例: `v0.1.2`）
+   - タグには `v` プレフィックス付きのバージョンを指定（例: `v0.2.0`）
+   - Release title にはバージョン番号を記載（例: `v0.2.0`）
    - CHANGELOG の内容を参考にリリースノートを記入する
 
 6. Release 作成イベントにより `.github/workflows/gradle-publish.yml` が発火し、Maven Central へ自動公開される


### PR DESCRIPTION
## 概要

v0.2.0 の Maven Central 公開に向けて、バージョン番号・README・CHANGELOG・リリース手順を整備しました。

## 変更内容

- build.gradle の Maven Central公開バージョンを 0.2.0 に更新
- READMEの依存関係例を 0.2.0 に更新
- CHANGELOG.md に 0.2.0 セクションを作成
- docs/release.md の例示バージョンを 0.2.0 に更新

## 注意

本PRでは GitHub Release作成、tag作成、Maven Central公開は行っていません。
PR merge後に、main から GitHub Release v0.2.0 を手動作成します。

## 確認

- git diff --check
- ./gradlew clean test
- ./gradlew build
